### PR TITLE
Mod 873 fix unable to get collection criterion from organization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,6 @@ Changelog
 - Adapt code to allow override of faceted context
   [mpeeters]
 
-
 0.16 (2021-04-20)
 -----------------
 

--- a/src/collective/eeafaceted/dashboard/browser/views.py
+++ b/src/collective/eeafaceted/dashboard/browser/views.py
@@ -36,17 +36,17 @@ class JSONCollectionsCount(BrowserView):
 
     """Produce json to update counts."""
 
-    def get_context(self):
-        faceted_context = self.context
-        while not IFacetedNavigable.providedBy(faceted_context) and not faceted_context.meta_type == 'Plone Site':
-            return faceted_context.aq_inner.aq_parent
+    def get_context(self, faceted_context):
+        while not IFacetedNavigable.providedBy(faceted_context) and \
+                not faceted_context.meta_type == 'Plone Site':
+            return self.get_context(faceted_context.aq_inner.aq_parent)
         return faceted_context
 
     def __call__(self):
         # view may be called on a faceted context or a sub-element, if it is a sub-element
         # get the first parent that is a faceted
         res = {}
-        faceted_context = self.get_context()
+        faceted_context = self.get_context(self.context)
         if faceted_context.meta_type != 'Plone Site':
             data = getCollectionLinkCriterion(faceted_context)
             widget = CollectionWidget(faceted_context, self.request, data)

--- a/src/collective/eeafaceted/dashboard/tests/test_views.py
+++ b/src/collective/eeafaceted/dashboard/tests/test_views.py
@@ -84,3 +84,23 @@ class TestJSONCollectionsCount(IntegrationTestCase):
             'countByCollection': []
         }
         self.assertEqual(self.view(), json.dumps(expected))
+
+    def test_with_sub_elements(self):
+        """Make sure especially the JSONCollectionsCount.get_context gets
+           the faceted context when the view is called from a sub/sub element."""
+        self.assertEqual(self.view.context, self.folder)
+        self.assertEqual(self.view(), '{"criterionId": "c1", "countByCollection": []}')
+        subfolder = api.content.create(
+            id='subfolder',
+            type='Folder',
+            title='Subfolder',
+            container=self.folder)
+        self.view.context = subfolder
+        self.assertEqual(self.view(), '{"criterionId": "c1", "countByCollection": []}')
+        subsubfolder = api.content.create(
+            id='subsubfolder',
+            type='Folder',
+            title='Subsubfolder',
+            container=subfolder)
+        self.view.context = subsubfolder
+        self.assertEqual(self.view(), '{"criterionId": "c1", "countByCollection": []}')


### PR DESCRIPTION
Salut @mpeeters 

depuis ton changement j'ai une erreur lorsque la vue @@json_collections_count est appelée depuis un sous élément dont le parent n'est pas un faceted.
Je pense que c'est juste un problème avec la récursivité de la méthode JSONCollectionsCount.get_context
J'ai adapté le code et ajouté un test, maintenant c'est ok de notre côté cependant, maintenant la méthode get_context reçoit le faceted_context (self.context par défaut) en paramètre, je suppose que tu devras aussi adapter le code de ton côté qui surcharge cette méthode...
Regarde si cette manière de faire te permet aussi de surcharger comme tu le souhaites sinon dis moi.
Merci,
Gauthier